### PR TITLE
Support Rails 5

### DIFF
--- a/brightbytes-sendgrid.gemspec
+++ b/brightbytes-sendgrid.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "actionmailer", ">= 3.2", "< 5.0.0"
+  spec.add_development_dependency "actionmailer", ">= 3.2", "< 6.0.0"
 
-  spec.add_dependency "activesupport", ">= 3.2", "< 5.0.0"
+  spec.add_dependency "activesupport", ">= 3.2", "< 6.0.0"
 end

--- a/lib/brightbytes/sendgrid.rb
+++ b/lib/brightbytes/sendgrid.rb
@@ -17,7 +17,8 @@ module Brightbytes
 
     included do
       delegate *Brightbytes::Sendgrid::SmtpApiHeader::DELEGATE_METHODS, to: :sendgrid, prefix: true
-      alias_method_chain :mail, :sendgrid
+      alias_method :mail_without_sendgrid, :mail
+      alias_method :mail, :mail_with_sendgrid
     end
     
     protected


### PR DESCRIPTION
### Changes
* Update deps to be compatible with `Rails 5`
* `alias_method_chain` is removed from `Rails 5`, so I inlined it to be compatible